### PR TITLE
Creates a new TourOption tag each iteration

### DIFF
--- a/django/vron/connector/api/viator.py
+++ b/django/vron/connector/api/viator.py
@@ -829,10 +829,12 @@ class Viator( XmlManager ):
                 self.response_xml.create_element( 'TourDescription', tour_element, tour['tour']['tour_description'] )
 
                 # creates tour options elements
-                tour_options_element = self.response_xml.create_element( 'TourOption', tour_element )
                 if tour['options']:
                     for option in tour['options']:
                         # Basic option info
+                        #creates a new TourOption each iteration
+                        tour_options_element = self.response_xml.create_element( 'TourOption', tour_element )
+                        
                         #self.response_xml.create_element( 'SupplierOptionCode', tour_options_element, option['option_code'] )
                         #self.response_xml.create_element( 'SupplierOptionName', tour_options_element, option['option_name'] )
                         self.response_xml.create_element( 'TourDepartureTime', tour_options_element, option['departure_time'] )


### PR DESCRIPTION
This is a solution for this requirement:

_It appears that in the response the field “Basis” is repeated within a single TourOption. This is incorrect, each Basis is the differentiation of a tour option, and therefore each must reside within a TourOption element._
